### PR TITLE
Programme Sorgho CNRA_JPS

### DIFF
--- a/Programme Sorgho CNRA_JPS
+++ b/Programme Sorgho CNRA_JPS
@@ -12,15 +12,19 @@
     <category field="biology"/>
     <issn>0962-1083</issn>
     <eissn>1365-294X</eissn>
-    <updated>2025-01-22T22:19:51+00:00</updated>
+    <updated>2025-08-22T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <summary>Custom citation style for Programme Sorgho CNRA_JPS, author-date format, compatible with journal submissions.</summary>
   </info>
+
+  <!-- Macros -->
   <macro name="editor-translator">
     <names variable="editor translator" prefix=" (" delimiter=", " suffix=")">
       <name initialize-with="" delimiter=", "/>
       <label form="short" prefix=", " text-case="capitalize-first" suffix="," strip-periods="true"/>
     </names>
   </macro>
+
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-et-al="never"/>
@@ -33,6 +37,7 @@
       </substitute>
     </names>
   </macro>
+
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
@@ -51,6 +56,7 @@
       </substitute>
     </names>
   </macro>
+
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
@@ -61,12 +67,15 @@
       </else>
     </choose>
   </macro>
+
   <macro name="publisher">
     <group delimiter=", ">
       <text variable="publisher"/>
       <text variable="publisher-place"/>
     </group>
   </macro>
+
+  <!-- Citation -->
   <citation collapse="year-suffix" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key variable="issued"/>
@@ -85,6 +94,8 @@
       </group>
     </layout>
   </citation>
+
+  <!-- Bibliography -->
   <bibliography hanging-indent="true" et-al-min="1" et-al-use-first="3" entry-spacing="0" line-spacing="2">
     <sort>
       <key macro="author-short"/>


### PR DESCRIPTION
This pull request adds a new CSL citation style for the "Programme Sorgho CNRA_JPS" references.

- Style Name: Programme Sorgho CNRA_JPS
- Target Journal / Program: CNRA Sorghum Research Program
- Citation Format: Author-Date (Harvard-style)
- Notes: Custom style for internal sorghum research citations. Supports journal articles, theses, book chapters, and conference papers.
- Author: Joseph Pascal SENE (joseph15.sene@gmail.com)
- Version: 1.0
- Tested on: Mendeley Reference Manager and Zotero
- License: Creative Commons Attribution-ShareAlike 3.0
- Summary: This style formats references according to CNRA internal requirements for sorghum research publications. 

All XML tags have been validated, and the style passes CSL tests locally.